### PR TITLE
support invoking funcs from Markdown, add jsonschemadoc func

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -1,0 +1,78 @@
+package docsite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/docsite/markdown"
+	"github.com/sourcegraph/go-jsonschema/jsonschema"
+	"github.com/sourcegraph/jsonschemadoc"
+)
+
+// createMarkdownFuncs creates the standard set of Markdown functions expected by documentation
+// content. Documentation pages can invoke these functions with special tags such as <div
+// markdown-func=myfunc1 myfunc:arg1="foo" />. The only function currently defined is jsonschemadoc,
+// which generates documentation for a JSON Schema.
+//
+// TODO: This is not strictly necessary to use with docsite. It could be extracted to a separate
+// package and made optional for callers. It's in this package for simplicity for now (because it is
+// used on both https://docs.sourcegraph.com and on the in-product /help pages on Sourcegraph).
+func createMarkdownFuncs(site *Site) markdown.FuncMap {
+	return markdown.FuncMap{
+		"jsonschemadoc": func(ctx context.Context, info markdown.FuncInfo, args map[string]string) (string, error) {
+			inputPath := args["path"]
+			if inputPath == "" {
+				return "", errors.New("no path to JSON Schema file is specified (use <div markdown-func=jsonschemadoc jsonschemadoc:path=PATH>)")
+			}
+
+			content, err := site.Content.OpenVersion(ctx, info.Version)
+			if err != nil {
+				return "", err
+			}
+			data, err := ReadFile(content, inputPath)
+			if err != nil {
+				return "", err
+			}
+
+			var schema *jsonschema.Schema
+			if err := json.Unmarshal(data, &schema); err != nil {
+				return "", err
+			}
+
+			// Support JSON references to emit documentation for a sub-definition.
+			if ref := args["ref"]; ref != "" {
+				if !strings.HasPrefix(ref, "#") {
+					return "", fmt.Errorf("invalid JSON Schema reference %q (only URI fragments are supported)", ref)
+				}
+				u, err := url.Parse(ref)
+				if err != nil {
+					return "", errors.WithMessage(err, "invalid JSON Schema reference")
+				}
+				// TODO(sqs): support the general case, not just #/definitions/Foo.
+				if !strings.HasPrefix(u.Fragment, "/definitions/") || strings.Count(u.Fragment, "/") != 2 {
+					return "", fmt.Errorf("unsupported JSON Schema reference %q (only simple #/defintions/Foo references are supported)", u.Fragment)
+				}
+				defName := strings.TrimPrefix(u.Fragment, "/definitions/")
+				if schema.Definitions == nil || (*schema.Definitions)[defName] == nil {
+					return "", fmt.Errorf("unable to resolve JSON Schema reference %q", u.Fragment)
+				}
+				schema = (*schema.Definitions)[defName]
+			}
+
+			out, err := jsonschemadoc.Generate(schema)
+			if err != nil {
+				return "", err
+			}
+
+			doc, err := markdown.Run(ctx, []byte("<div class='pre-wrap'>\n```javascript\n"+string(out)+"\n```\n</div>"), markdown.Options{})
+			if err != nil {
+				return "", err
+			}
+			return string(doc.HTML), nil
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/shurcooL/sanitized_anchor_name v1.0.0
+	github.com/sourcegraph/jsonschemadoc v0.0.0-20190214000648-1850b818f08c // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190110200230-915654e7eabc

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,12 @@ github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 h1:
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sourcegraph/go-jsonschema v0.0.0-20190205151546-7939fa138765 h1:bFHV2WYU7J7MPdKTyaR6M7Ahhbn4cIdvbTRIRXprenM=
+github.com/sourcegraph/go-jsonschema v0.0.0-20190205151546-7939fa138765/go.mod h1:6DfNy4BLIggAeittTJ8o9z/6d1ly+YujBTSnv03i7Bk=
+github.com/sourcegraph/jsonschemadoc v0.0.0-20190213075727-fee9160d1880 h1:ohhgp/NMJhklUGX2Nng+bmJ46XMHBljKElLd4uQUWHA=
+github.com/sourcegraph/jsonschemadoc v0.0.0-20190213075727-fee9160d1880/go.mod h1:7jdxMdV6lVaEQ0MhiqoM7qAxi23fy2IBoXD8fN0z4po=
+github.com/sourcegraph/jsonschemadoc v0.0.0-20190214000648-1850b818f08c h1:MXlcJZ1VL5nNGkCj6ZTT71P4pImPkeG2lvzcJYzGvU4=
+github.com/sourcegraph/jsonschemadoc v0.0.0-20190214000648-1850b818f08c/go.mod h1:ovHiFoMDwf4nf7ynAc7lIhD4w0nc/6tO27DtVzqYrTQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/handler.go
+++ b/handler.go
@@ -86,7 +86,7 @@ func (s *Site) Handler() http.Handler {
 			filePath, fileData, err := resolveAndReadAll(content, r.URL.Path)
 			if err == nil {
 				// Content page found.
-				data.Content, err = s.newContentPage(filePath, fileData, contentVersion)
+				data.Content, err = s.newContentPage(r.Context(), filePath, fileData, contentVersion)
 			}
 			if err != nil {
 				// Content page not found.

--- a/markdown/func.go
+++ b/markdown/func.go
@@ -1,0 +1,104 @@
+package markdown
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+func evalMarkdownFuncs(ctx context.Context, htmlFragment []byte, opt Options) ([]byte, error) {
+	z := html.NewTokenizer(bytes.NewReader(htmlFragment))
+	var buf bytes.Buffer
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			if z.Err() == io.EOF {
+				break
+			}
+			return nil, errors.WithMessage(z.Err(), "while evaluating Markdown function tags")
+		}
+		tok := z.Token()
+		invokedFunc := false
+		if (tok.Type == html.StartTagToken || tok.Type == html.SelfClosingTagToken) && tok.DataAtom == atom.Div {
+			funcName, args := getMarkdownFuncInvocation(tok)
+			if funcName != "" {
+				f := opt.Funcs[funcName]
+				if f == nil {
+					return nil, fmt.Errorf("Markdown function %q is not defined", funcName)
+				}
+
+				out, err := func() (out string, err error) {
+					defer func() {
+						if e := recover(); e != nil {
+							err = errors.New(fmt.Sprint(e))
+						}
+					}()
+					return f(ctx, opt.FuncInfo, args)
+				}()
+				if err != nil {
+					return nil, errors.WithMessagef(err, "error in Markdown function %q", funcName)
+				}
+				buf.WriteString(out)
+				invokedFunc = true
+
+				// Remove all contents. This makes it so that the contents can be like "noscript",
+				// shown only to users viewing the raw Markdown and not the Markdown as
+				// rendered/evaluated by this package.
+				if tok.Type == html.StartTagToken {
+					if err := consumeUntilCloseTag(z, funcName); err != nil {
+						return nil, err
+					}
+				}
+				continue
+			}
+		}
+
+		if !invokedFunc {
+			buf.WriteString(tok.String())
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func getMarkdownFuncInvocation(tok html.Token) (funcName string, args map[string]string) {
+	for _, attr := range tok.Attr {
+		if attr.Key == "markdown-func" {
+			funcName = attr.Val
+			break
+		}
+	}
+	if funcName != "" {
+		argKeyPrefix := funcName + ":"
+		for _, attr := range tok.Attr {
+			if strings.HasPrefix(attr.Key, argKeyPrefix) {
+				if args == nil {
+					args = map[string]string{}
+				}
+				args[strings.TrimPrefix(attr.Key, argKeyPrefix)] = attr.Val
+			}
+		}
+	}
+	return funcName, args
+}
+
+func consumeUntilCloseTag(z *html.Tokenizer, funcName string) error {
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			if z.Err() == io.EOF {
+				return fmt.Errorf("tag for Markdown function %q is never closed", funcName)
+			}
+			return errors.WithMessagef(z.Err(), "while scanning for Markdown function close tag %q", funcName)
+		}
+		tok := z.Token()
+		if tok.Type == html.EndTagToken {
+			return nil
+		}
+	}
+}

--- a/markdown/func_test.go
+++ b/markdown/func_test.go
@@ -1,0 +1,57 @@
+package markdown
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+func TestGetMarkdownFuncInvocation(t *testing.T) {
+	tests := []struct {
+		tok          html.Token
+		wantFuncName string
+		wantArgs     map[string]string
+	}{
+		{
+			tok: html.Token{
+				Attr: []html.Attribute{},
+			},
+			wantFuncName: "",
+			wantArgs:     nil,
+		},
+		{
+			tok: html.Token{
+				Attr: []html.Attribute{{Key: "x", Val: "y"}},
+			},
+			wantFuncName: "",
+			wantArgs:     nil,
+		},
+		{
+			tok: html.Token{
+				Attr: []html.Attribute{{Key: "markdown-func", Val: "f"}},
+			},
+			wantFuncName: "f",
+			wantArgs:     nil,
+		},
+		{
+			tok: html.Token{
+				Attr: []html.Attribute{{Key: "f:a", Val: "1"}, {Key: "markdown-func", Val: "f"}, {Key: "f:b", Val: "2"}},
+			},
+			wantFuncName: "f",
+			wantArgs:     map[string]string{"a": "1", "b": "2"},
+		},
+	}
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			funcName, args := getMarkdownFuncInvocation(test.tok)
+			if funcName != test.wantFuncName {
+				t.Errorf("got funcName %q, want %q", funcName, test.wantFuncName)
+			}
+			if !reflect.DeepEqual(args, test.wantArgs) {
+				t.Errorf("got args %q, want %q", args, test.wantArgs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This lets us show JSON Schema documentation for site config, critical config, and external services without needing to manually update it.

Doc pages can contain a special tag like the following that is transformed into a code snippet with JSON Schema documentation:

```
<div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/bitbucket_server.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/bitbucket_server) to see rendered content.</div>
```

helps with https://github.com/sourcegraph/sourcegraph/issues/2067