### PR TITLE
work around issue with tables containing `...|...`

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"net/url"
+
+	"github.com/pkg/errors"
 
 	"github.com/Depado/bfchroma"
 	"github.com/alecthomas/chroma/styles"

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -60,6 +60,31 @@ title: Metadata title
 
 func TestRenderer(t *testing.T) {
 	ctx := context.Background()
+	t.Run("table with `|`", func(t *testing.T) {
+		doc, err := Run(ctx, []byte("a  |  b\n---|---\nc  | `|`"), Options{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := `<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>c</td>
+<td><code>|</code></td>
+</tr>
+</tbody>
+</table>
+`
+		if string(doc.HTML) != want {
+			t.Errorf("\ngot:  '%s'\nwant: '%s'", string(doc.HTML), want)
+		}
+	})
 	t.Run("heading anchor link ignores special chars", func(t *testing.T) {
 		doc, err := Run(ctx, []byte(`## A ' B " C & D ? E`), Options{})
 		if err != nil {


### PR DESCRIPTION
With this change, pipes inside backtick-delimited code blocks are converted into obscure unicode characters (triple-vertical-bars) to avoid being interpreted as table-delimiting characters during markdown parsing. After rendering to HTML, the triple bars are converted back to pipes.

This works around https://github.com/sourcegraph/sourcegraph/issues/3869.