### PR TITLE
evaluate Markdown funcs in indexed content for search

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -25,7 +25,7 @@ import (
 // package and made optional for callers. It's in this package for simplicity for now (because it is
 // used on both https://docs.sourcegraph.com and on the in-product /help pages on Sourcegraph).
 func createMarkdownFuncs(site *Site) markdown.FuncMap {
-	return markdown.FuncMap{
+	m := markdown.FuncMap{
 		"jsonschemadoc": func(ctx context.Context, info markdown.FuncInfo, args map[string]string) (string, error) {
 			inputPath := args["path"]
 			if inputPath == "" {
@@ -106,4 +106,13 @@ func createMarkdownFuncs(site *Site) markdown.FuncMap {
 			return string(doc.HTML), nil
 		},
 	}
+	if testMarkdownFuncs != nil {
+		for name, f := range testMarkdownFuncs {
+			m[name] = f
+		}
+	}
+	return m
 }
+
+// testMarkdownFuncs can be set by tests to inject Markdown functions.
+var testMarkdownFuncs markdown.FuncMap

--- a/markdown/func.go
+++ b/markdown/func.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/net/html/atom"
 )
 
-func evalMarkdownFuncs(ctx context.Context, htmlFragment []byte, opt Options) ([]byte, error) {
+func EvalMarkdownFuncs(ctx context.Context, htmlFragment []byte, opt Options) ([]byte, error) {
 	z := html.NewTokenizer(bytes.NewReader(htmlFragment))
 	var buf bytes.Buffer
 	for {

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -220,7 +220,7 @@ func (r *renderer) RenderNode(ctx context.Context, w io.Writer, node *blackfrida
 		// Evaluate Markdown funcs (<div markdown-func=name ...> nodes), using a heuristic to
 		// skip blocks that don't contain any invocations.
 		if entering {
-			if v, err := evalMarkdownFuncs(ctx, node.Literal, r.Options); err == nil {
+			if v, err := EvalMarkdownFuncs(ctx, node.Literal, r.Options); err == nil {
 				node.Literal = v
 			} else {
 				r.errors = append(r.errors, err)


### PR DESCRIPTION
When searching, the search should match against the logical content of the page with Markdown functions (such as `jsonschemadoc`) evaluated. Fix https://github.com/sourcegraph/about/issues/361.