### PR TITLE
markdown: remove setting code block background color to #fff

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -11,10 +11,10 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/pkg/errors"
-
 	"github.com/Depado/bfchroma"
+	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/styles"
+	"github.com/pkg/errors"
 	"github.com/russross/blackfriday/v2"
 )
 
@@ -70,10 +70,27 @@ func NewParser(renderer blackfriday.Renderer) *blackfriday.Markdown {
 	)
 }
 
+// styles.VisualStudio without bg:#ffffff.
+var chromaStyle = styles.Register(chroma.MustNewStyle("vs", chroma.StyleEntries{
+	chroma.Comment:           "#008000",
+	chroma.CommentPreproc:    "#0000ff",
+	chroma.Keyword:           "#0000ff",
+	chroma.OperatorWord:      "#0000ff",
+	chroma.KeywordType:       "#2b91af",
+	chroma.NameClass:         "#2b91af",
+	chroma.LiteralString:     "#a31515",
+	chroma.GenericHeading:    "bold",
+	chroma.GenericSubheading: "bold",
+	chroma.GenericEmph:       "italic",
+	chroma.GenericStrong:     "bold",
+	chroma.GenericPrompt:     "bold",
+	chroma.Error:             "border:#FF0000",
+}))
+
 // NewBfRenderer creates the default blackfriday renderer to be passed to NewParser()
 func NewBfRenderer() blackfriday.Renderer {
 	return bfchroma.NewRenderer(
-		bfchroma.ChromaStyle(styles.VisualStudio),
+		bfchroma.ChromaStyle(chromaStyle),
 		bfchroma.Extend(
 			blackfriday.NewHTMLRenderer(blackfriday.HTMLRendererParameters{
 				Flags: blackfriday.CommonHTMLFlags,

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -155,7 +155,7 @@ func TestRenderer(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := `<pre style="background-color:#fff"><span style="color:#00f">var</span> foo <span style="color:#00f">struct</span>{}` + "\n" + `</pre>`
+		want := `<pre style=""><span style="color:#00f">var</span> foo <span style="color:#00f">struct</span>{}` + "\n" + `</pre>`
 		if string(doc.HTML) != want {
 			t.Errorf("\ngot:  %s\nwant: %s", string(doc.HTML), want)
 		}
@@ -165,7 +165,7 @@ func TestRenderer(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := `<pre style="background-color:#fff"><span style="color:#00f">const</span> foo = <span style="color:#a31515">&#39;bar&#39;</span>` + "\n" + `</pre>`
+		want := `<pre style=""><span style="color:#00f">const</span> foo = <span style="color:#a31515">&#39;bar&#39;</span>` + "\n" + `</pre>`
 		if string(doc.HTML) != want {
 			t.Errorf("\ngot:  %s\nwant: %s", string(doc.HTML), want)
 		}
@@ -175,7 +175,7 @@ func TestRenderer(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := `<pre style="background-color:#fff">{&#34;foo&#34;: 123}` + "\n" + `</pre>`
+		want := `<pre style="">{&#34;foo&#34;: 123}` + "\n" + `</pre>`
 		if string(doc.HTML) != want {
 			t.Errorf("\ngot:  %s\nwant: %s", string(doc.HTML), want)
 		}


### PR DESCRIPTION
This PR removes setting code block background to #fff, so it could inherit.

Before:
![image](https://user-images.githubusercontent.com/2946214/72912102-166e8b00-3d76-11ea-96d3-26b75b51b29b.png)

After:
![image](https://user-images.githubusercontent.com/2946214/72912113-1b333f00-3d76-11ea-9c3f-4f0ac3eb4acc.png)
