### PR TITLE
fix panic when highlighting query matches on unicode text

### DIFF
--- a/internal/search/index/index.go
+++ b/internal/search/index/index.go
@@ -12,7 +12,7 @@ type Document struct {
 	ID    DocID  // the document ID
 	Title string // the document title
 	URL   string // the document URL
-	Data  []byte // the text content
+	Data  string // the text content
 }
 
 // Index is a search index.

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -21,11 +21,21 @@ func TestQuery_FindAllIndex(t *testing.T) {
 			query: "cc bb",
 			want:  []Match{{3, 5}, {6, 8}},
 		},
+		"case-insensitive": {
+			text:  "a A b B",
+			query: "a B",
+			want:  []Match{{0, 1}, {2, 3}, {4, 5}, {6, 7}},
+		},
+		"wide chars": {
+			text:  "a \x9f\x92\xa1 a",
+			query: "a",
+			want:  []Match{{0, 1}, {6, 7}},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			q := Parse(test.query)
-			matches := q.FindAllIndex([]byte(test.text))
+			matches := q.FindAllIndex(test.text)
 			if !reflect.DeepEqual(matches, test.want) {
 				t.Errorf("got matches %v, want %v", matches, test.want)
 			}

--- a/internal/search/query/token.go
+++ b/internal/search/query/token.go
@@ -1,0 +1,15 @@
+package query
+
+import "regexp"
+
+type token struct {
+	str     string
+	pattern *regexp.Regexp
+}
+
+func newToken(str string) token {
+	return token{
+		str:     str,
+		pattern: regexp.MustCompile("(?i)" + regexp.QuoteMeta(str)),
+	}
+}

--- a/internal/search/sections.go
+++ b/internal/search/sections.go
@@ -14,7 +14,7 @@ type SectionResult struct {
 	Excerpts   []string // the match excerpt
 }
 
-func documentSectionResults(data []byte, query query.Query) ([]SectionResult, error) {
+func documentSectionResults(data string, query query.Query) ([]SectionResult, error) {
 	type stackEntry struct {
 		id    string
 		title string
@@ -22,7 +22,7 @@ func documentSectionResults(data []byte, query query.Query) ([]SectionResult, er
 	}
 	stack := []stackEntry{{}}
 	cur := func() stackEntry { return stack[len(stack)-1] }
-	ast := markdown.NewParser(markdown.NewBfRenderer()).Parse(data)
+	ast := markdown.NewParser(markdown.NewBfRenderer()).Parse([]byte(data))
 	markdown.SetHeadingIDs(ast)
 
 	var results []SectionResult
@@ -73,7 +73,7 @@ func documentSectionResults(data []byte, query query.Query) ([]SectionResult, er
 		}
 
 		if entering && (node.Type == blackfriday.Paragraph || node.Type == blackfriday.Item || node.Type == blackfriday.Heading || node.Type == blackfriday.BlockQuote || node.Type == blackfriday.Code) {
-			text := markdown.RenderText(node)
+			text := string(markdown.RenderText(node))
 			if matches := query.FindAllIndex(text); len(matches) > 0 {
 				// Don't include excerpts for heading because all of the heading is considered the
 				// match.
@@ -82,7 +82,7 @@ func documentSectionResults(data []byte, query query.Query) ([]SectionResult, er
 					excerpts = make([]string, len(matches))
 					for i, match := range matches {
 						const excerptMaxLength = 220
-						excerpts[i] = excerpt(string(text), match[0], match[1], excerptMaxLength)
+						excerpts[i] = excerpt(text, match[0], match[1], excerptMaxLength)
 					}
 				}
 

--- a/internal/search/sections_test.go
+++ b/internal/search/sections_test.go
@@ -41,7 +41,7 @@ bb zz`,
 		t.Run(name, func(t *testing.T) {
 			for queryStr, wantResults := range test.wantQueryResults {
 				t.Run(queryStr, func(t *testing.T) {
-					results, err := documentSectionResults([]byte(test.data), query.Parse(queryStr))
+					results, err := documentSectionResults(test.data, query.Parse(queryStr))
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/search.go
+++ b/search.go
@@ -37,7 +37,7 @@ func (s *Site) Search(ctx context.Context, contentVersion string, queryStr strin
 			ID:    index.DocID(page.FilePath),
 			Title: markdown.GetTitle(ast),
 			URL:   s.Base.ResolveReference(&url.URL{Path: page.Path}).String(),
-			Data:  data,
+			Data:  string(data),
 		}); err != nil {
 			return nil, err
 		}
@@ -73,22 +73,7 @@ func (s *Site) renderTextContent(ctx context.Context, page *ContentPage, ast *bl
 func (s *Site) renderSearchPage(queryStr string, result *search.Result) ([]byte, error) {
 	query := query.Parse(queryStr)
 	tmpl, err := s.getTemplate(s.Templates, searchTemplateName, template.FuncMap{
-		"highlight": func(text string) template.HTML {
-			var s []string
-			c := 0
-			for _, match := range query.FindAllIndex([]byte(text)) {
-				start, end := match[0], match[1]
-				if start > c {
-					s = append(s, html.EscapeString(text[c:start]))
-				}
-				s = append(s, "<strong>"+html.EscapeString(text[start:end])+"</strong>")
-				c = end
-			}
-			if c < len(text) {
-				s = append(s, html.EscapeString(text[c:]))
-			}
-			return template.HTML(strings.Join(s, ""))
-		},
+		"highlight": func(text string) template.HTML { return highlight(query, text) },
 	})
 	if err != nil {
 		return nil, err
@@ -107,4 +92,22 @@ func (s *Site) renderSearchPage(queryStr string, result *search.Result) ([]byte,
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+// highlight returns an HTML fragment with matches of the pattern in text wrapped in <strong>.
+func highlight(query query.Query, text string) template.HTML {
+	var s []string
+	c := 0
+	for _, match := range query.FindAllIndex(text) {
+		start, end := match[0], match[1]
+		if start > c {
+			s = append(s, html.EscapeString(text[c:start]))
+		}
+		s = append(s, "<strong>"+html.EscapeString(text[start:end])+"</strong>")
+		c = end
+	}
+	if c < len(text) {
+		s = append(s, html.EscapeString(text[c:]))
+	}
+	return template.HTML(strings.Join(s, ""))
 }


### PR DESCRIPTION
If the underlying text had a different length when `bytes.ToLower` was called on it, a panic would occur (fixes https://github.com/sourcegraph/docsite/issues/41).