### PR TITLE
redirect from trailing slash to non-trailing slash URLs

### DIFF
--- a/content.go
+++ b/content.go
@@ -30,7 +30,7 @@ func contentFilePathToPath(filePath string) string {
 // resolveAndReadAll resolves a URL path to a file path, adding a file extension (.md) and a
 // directory index filename as needed. It also returns the file content.
 func resolveAndReadAll(fs http.FileSystem, path string) (filePath string, data []byte, err error) {
-	filePath = path + ".md"
+	filePath = strings.TrimSuffix(path, "/") + ".md"
 	data, err = ReadFile(fs, filePath)
 	if isDir(fs, filePath) || (os.IsNotExist(err) && !strings.HasSuffix(path, string(os.PathSeparator)+"index")) {
 		// Try looking up the path as a directory and reading its index file (index.md).

--- a/handler.go
+++ b/handler.go
@@ -144,6 +144,12 @@ func (s *Site) Handler() http.Handler {
 			// Version found.
 			filePath, fileData, err := resolveAndReadAll(content, r.URL.Path)
 			if err == nil {
+				// Strip trailing slashes for consistency.
+				if strings.HasSuffix(r.URL.Path, "/") {
+					http.Redirect(w, r, path.Join(basePath, strings.TrimSuffix(r.URL.Path, "/")), http.StatusMovedPermanently)
+					return
+				}
+
 				// Content page found.
 				data.Content, err = s.newContentPage(r.Context(), filePath, fileData, contentVersion)
 			}

--- a/handler_test.go
+++ b/handler_test.go
@@ -110,6 +110,33 @@ query "{{.Query}}":
 				checkContentPageResponse(t, rr)
 			})
 
+			t.Run("index page with trailing slash", func(t *testing.T) {
+				rr := httptest.NewRecorder()
+				req, _ := http.NewRequest("GET", "/a/b/", nil)
+				handler.ServeHTTP(rr, req)
+				checkResponseStatus(t, rr, http.StatusMovedPermanently)
+				if got, want := rr.Header().Get("Location"), "/a/b"; got != want {
+					t.Errorf("got Location %q, want %q", got, want)
+				}
+			})
+
+			t.Run("non-index page with trailing slash", func(t *testing.T) {
+				rr := httptest.NewRecorder()
+				req, _ := http.NewRequest("GET", "/a/b/c/", nil)
+				handler.ServeHTTP(rr, req)
+				checkResponseStatus(t, rr, http.StatusMovedPermanently)
+				if got, want := rr.Header().Get("Location"), "/a/b/c"; got != want {
+					t.Errorf("got Location %q, want %q", got, want)
+				}
+			})
+
+			t.Run("non-existent page with trailing slash", func(t *testing.T) {
+				rr := httptest.NewRecorder()
+				req, _ := http.NewRequest("GET", "/a/b/d/", nil)
+				handler.ServeHTTP(rr, req)
+				checkResponseStatus(t, rr, http.StatusNotFound)
+			})
+
 			t.Run("asset", func(t *testing.T) {
 				rr := httptest.NewRecorder()
 				req, _ := http.NewRequest("GET", "/a/b/img/f.gif", nil)

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/url"
 	"regexp"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -222,6 +223,11 @@ func (r *renderer) RenderNode(ctx context.Context, w io.Writer, node *blackfrida
 				}
 				if r.Options.Base != nil {
 					dest = r.Options.Base.ResolveReference(dest)
+
+					// Remove trailing slashes, which are never used for content page links (except the root).
+					if dest.Path != "/" {
+						dest.Path = strings.TrimSuffix(dest.Path, "/")
+					}
 				}
 				node.LinkData.Destination = []byte(dest.String())
 			}


### PR DESCRIPTION
The canonical page URLs used by docsite have no trailing slash, so a URL with a trailing slash should redirect to a URL without one.

fix #55