### PR TITLE
Use first heading for title

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -319,13 +319,9 @@ func getDocumentTopTitleHeadingNode(doc *blackfriday.Node) *blackfriday.Node {
 	}
 
 	for node := doc.FirstChild; node != nil; node = node.Next {
-		if node.Type == blackfriday.HTMLBlock && isOnlyHTMLComment(node.Literal) {
-			continue
-		}
 		if node.Type == blackfriday.Heading && node.HeadingData.Level == 1 {
 			return node
 		}
-		return nil
 	}
 	return nil
 }

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -452,7 +452,7 @@ func TestGetTitle(t *testing.T) {
 		"<!-- a -->\n# h":   "h",
 		"<!-- a --> \n# h":  "h",
 		"<!-- a -->\n\n# h": "h",
-		"a\n# h":            "",
+		"a\n# h":            "h",
 	}
 	for input, wantTitle := range tests {
 		t.Run(input, func(t *testing.T) {


### PR DESCRIPTION
Markdown pages can have content before the first heading, e.g. HTML tags containing a floated image, a style tag, a script, etc. This causes the page to show up as "Untitled" in search, see e.g. https://github.com/sourcegraph/about/pull/1892. I've also seen this with some other pages. Comments were explicitly handled but all other tags were not. This changes it to simply use the first level-1 heading it can find, no matter if there are any other tags before it.