### PR TITLE
disable serving other versions of content

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -95,19 +95,13 @@ func (s *Site) Handler() http.Handler {
 			}
 		}
 
-		// Support requests for other versions of content.
+		// Support was removed for requests for other versions of content.
+		//
+		// TODO(sqs): finish removing all code that supported this
 		var contentVersion string
 		if strings.HasPrefix(r.URL.Path, "@") {
-			end := strings.Index(r.URL.Path[1:], "/")
-			var urlPath string
-			if end == -1 {
-				urlPath = ""
-				contentVersion = r.URL.Path[1:]
-			} else {
-				urlPath = r.URL.Path[1+end+1:]
-				contentVersion = r.URL.Path[1 : 1+end]
-			}
-			r = requestShallowCopyWithURLPath(r, urlPath)
+			http.Error(w, "only the default branch is served", http.StatusNotFound)
+			return
 		}
 
 		if IsContentAsset(r.URL.Path) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -149,81 +149,25 @@ query "{{.Query}}":
 		})
 
 		t.Run("other version", func(t *testing.T) {
-			t.Run("root", func(t *testing.T) {
+			t.Run("not served", func(t *testing.T) {
 				rr := httptest.NewRecorder()
 				rr.Body = new(bytes.Buffer)
 				req, _ := http.NewRequest("GET", "/@otherversion", nil)
 				handler.ServeHTTP(rr, req)
-				checkResponseHTTPOK(t, rr)
-				checkContentPageResponse(t, rr)
-				if want := "other version index"; !strings.Contains(rr.Body.String(), want) {
-					t.Errorf("got body %q, want contains %q", rr.Body.String(), want)
-				}
-			})
-
-			t.Run("page", func(t *testing.T) {
-				rr := httptest.NewRecorder()
-				rr.Body = new(bytes.Buffer)
-				req, _ := http.NewRequest("GET", "/@otherversion/a", nil)
-				handler.ServeHTTP(rr, req)
-				checkResponseHTTPOK(t, rr)
-				checkContentPageResponse(t, rr)
-				if want := "other version a"; !strings.Contains(rr.Body.String(), want) {
-					t.Errorf("got body %q, want contains %q", rr.Body.String(), want)
-				}
-			})
-		})
-
-		t.Run("version not found", func(t *testing.T) {
-			t.Run("root", func(t *testing.T) {
-				rr := httptest.NewRecorder()
-				rr.Body = new(bytes.Buffer)
-				req, _ := http.NewRequest("GET", "/@badversion", nil)
-				handler.ServeHTTP(rr, req)
 				checkResponseStatus(t, rr, http.StatusNotFound)
-				checkContentPageResponse(t, rr)
-				if want := "content version not found"; !strings.Contains(rr.Body.String(), want) {
-					t.Errorf("got body %q, want contains %q", rr.Body.String(), want)
-				}
-			})
-
-			t.Run("page", func(t *testing.T) {
-				rr := httptest.NewRecorder()
-				rr.Body = new(bytes.Buffer)
-				req, _ := http.NewRequest("GET", "/@badversion/a", nil)
-				handler.ServeHTTP(rr, req)
-				checkResponseStatus(t, rr, http.StatusNotFound)
-				checkContentPageResponse(t, rr)
-				if want := "content version not found"; !strings.Contains(rr.Body.String(), want) {
-					t.Errorf("got body %q, want contains %q", rr.Body.String(), want)
-				}
 			})
 		})
 
 		t.Run("page not found", func(t *testing.T) {
-			t.Run("default version", func(t *testing.T) {
-				rr := httptest.NewRecorder()
-				rr.Body = new(bytes.Buffer)
-				req, _ := http.NewRequest("GET", "/doesntexist", nil)
-				handler.ServeHTTP(rr, req)
-				checkResponseStatus(t, rr, http.StatusNotFound)
-				checkContentPageResponse(t, rr)
-				if want := "content page not found"; !strings.Contains(rr.Body.String(), want) {
-					t.Errorf("got body %q, want contains %q", rr.Body.String(), want)
-				}
-			})
-
-			t.Run("other version", func(t *testing.T) {
-				rr := httptest.NewRecorder()
-				rr.Body = new(bytes.Buffer)
-				req, _ := http.NewRequest("GET", "/@otherversion/doesntexist", nil)
-				handler.ServeHTTP(rr, req)
-				checkResponseStatus(t, rr, http.StatusNotFound)
-				checkContentPageResponse(t, rr)
-				if want := "content page not found"; !strings.Contains(rr.Body.String(), want) {
-					t.Errorf("got body %q, want contains %q", rr.Body.String(), want)
-				}
-			})
+			rr := httptest.NewRecorder()
+			rr.Body = new(bytes.Buffer)
+			req, _ := http.NewRequest("GET", "/doesntexist", nil)
+			handler.ServeHTTP(rr, req)
+			checkResponseStatus(t, rr, http.StatusNotFound)
+			checkContentPageResponse(t, rr)
+			if want := "content page not found"; !strings.Contains(rr.Body.String(), want) {
+				t.Errorf("got body %q, want contains %q", rr.Body.String(), want)
+			}
 		})
 	})
 


### PR DESCRIPTION
It is rarely used to visit https://docs.sourcegraph.com/@someotherrevision/somepath. But this feature adds a lot of complexity and has caused memory leaks and other problems.

This commit just disables the functionality. Removal will come later. I wanted to disable it for now because it's fast to do so, and so then we can remove it later knowing that it definitely wasn't still in use.