### PR TITLE
Fix rendering of plaintext blocks

### DIFF
--- a/markdown/code_style_renderer.go
+++ b/markdown/code_style_renderer.go
@@ -13,12 +13,15 @@ type CodeStyleRenderer struct {
 
 func (c CodeStyleRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
 	if node.Type == blackfriday.CodeBlock {
-		if lang := string(node.Info); lang != "" {
-			fmt.Fprintf(w, `<pre class="chroma %s">`, lang)
-			walkStatus := c.Renderer.RenderNode(w, node, entering)
-			fmt.Fprint(w, "</pre>")
-			return walkStatus
+		lang := string(node.Info)
+		if lang == "" {
+			lang = "plaintext"
 		}
+
+		fmt.Fprintf(w, `<pre class="chroma %s">`, lang)
+		walkStatus := c.Renderer.RenderNode(w, node, entering)
+		fmt.Fprint(w, "</pre>")
+		return walkStatus
 	}
 
 	return c.Renderer.RenderNode(w, node, entering)


### PR DESCRIPTION
The logic for adding the language name to the class skipped fences where
the language wasn't specified. Now, we treat those as plaintext.

Before:
<img width="871" alt="Screen Shot 2021-03-24 at 15 33 22" src="https://user-images.githubusercontent.com/12631702/112386240-45ec9080-8cb6-11eb-95db-da75e6f18959.png">


After: 
<img width="911" alt="Screen Shot 2021-03-24 at 15 32 22" src="https://user-images.githubusercontent.com/12631702/112386149-22c1e100-8cb6-11eb-8096-13f4064eb49b.png">