### PR TITLE
Remove use of ioutil package

### DIFF
--- a/cmd/docsite/serve.go
+++ b/cmd/docsite/serve.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -49,11 +48,11 @@ func init() {
 		}
 		if *tlsCertPath != "" || *tlsKeyPath != "" {
 			log.Printf("# TLS listener enabled")
-			tlsCert, err := ioutil.ReadFile(*tlsCertPath)
+			tlsCert, err := os.ReadFile(*tlsCertPath)
 			if err != nil {
 				return err
 			}
-			tlsKey, err := ioutil.ReadFile(*tlsKeyPath)
+			tlsKey, err := os.ReadFile(*tlsKeyPath)
 			if err != nil {
 				return err
 			}

--- a/cmd/docsite/site.go
+++ b/cmd/docsite/site.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -35,7 +34,7 @@ func siteFromFlags() (*docsite.Site, *docsiteConfig, error) {
 
 	paths := filepath.SplitList(*configPath)
 	for _, path := range paths {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if os.IsNotExist(err) {
 			continue
 		} else if err != nil {
@@ -329,7 +328,7 @@ func zipFileSystemAtURL(url, dir string) (http.FileSystem, error) {
 	} else if resp.StatusCode != http.StatusOK {
 		return nil, &os.PathError{Op: "Get", Path: url, Err: fmt.Errorf("HTTP response status code %d", resp.StatusCode)}
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +363,7 @@ func mapFromZipArchive(z *zip.Reader, dir string) (map[string]string, error) {
 		if err != nil {
 			return nil, errors.WithMessagef(err, "open %q", zf.Name)
 		}
-		data, err := ioutil.ReadAll(f)
+		data, err := io.ReadAll(f)
 		f.Close()
 		if err != nil {
 			return nil, errors.WithMessagef(err, "read %q", zf.Name)

--- a/template.go
+++ b/template.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -27,7 +26,7 @@ func (s *Site) getTemplate(templatesFS http.FileSystem, name string, extraFuncs 
 			return nil, err
 		}
 		defer f.Close()
-		data, err := ioutil.ReadAll(f)
+		data, err := io.ReadAll(f)
 		if err != nil {
 			return nil, err
 		}

--- a/util.go
+++ b/util.go
@@ -1,7 +1,6 @@
 package docsite
 
 import (
-	"io/ioutil"
 	"net/http"
 )
 
@@ -11,5 +10,5 @@ func ReadFile(fs http.FileSystem, path string) ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close()
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)