### PR TITLE
Add support for more metadata fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The site data describes the location of its templates, assets, and content. It i
 - `content`: a VFS URL for the Markdown content files.
 - `contentExcludePattern`: a regular expression specifying Markdown content files to exclude.
 - `baseURLPath`: the URL path where the site is available (such as `/` or `/help/`).
+- `rootURL`: (optional) the root URL (scheme + host). Only used for rare cases where this is absolutely necessary, such as SEO tags fox example.
 - `templates`: a VFS URL for the [Go-style HTML templates](https://golang.org/pkg/html/template/) used to render site pages.
 - `assets`: a VFS URL for the static assets referred to in the HTML templates (such as CSS stylesheets).
 - `assetsBaseURLPath`: the URL path where the assets are available (such as `/assets/`).

--- a/cmd/docsite/site.go
+++ b/cmd/docsite/site.go
@@ -55,6 +55,7 @@ type docsiteConfig struct {
 	ContentExcludePattern string
 	DefaultContentBranch  string
 	BaseURLPath           string
+	RootURL               string
 	Templates             string
 	Assets                string
 	AssetsBaseURLPath     string
@@ -82,6 +83,19 @@ func partialSiteFromConfig(config docsiteConfig) (*docsite.Site, error) {
 	}
 	if config.BaseURLPath != "" {
 		site.Base = &url.URL{Path: config.BaseURLPath}
+	}
+	if config.RootURL != "" {
+		var err error
+		site.Root, err = url.Parse(config.RootURL)
+		if err != nil {
+			return nil, err
+		}
+		if site.Root.Scheme == "" || site.Root.Host == "" {
+			return nil, fmt.Errorf(
+				"invalid RootURL, should either be blank or must include scheme and host, got %s instead",
+				config.RootURL,
+			)
+		}
 	}
 	if config.AssetsBaseURLPath != "" {
 		site.AssetsBase = &url.URL{Path: config.AssetsBaseURLPath}

--- a/markdown/metadata.go
+++ b/markdown/metadata.go
@@ -10,13 +10,12 @@ import (
 type Metadata struct {
 	IgnoreDisconnectedPageCheck bool `yaml:"ignoreDisconnectedPageCheck"`
 
-	Title         string   `yaml:"title"`
-	Description   string   `yaml:"description"`
-	Category      string   `yaml:"category"`
-	CanonicalPath string   `yaml:"canonicalPath"`
-	ImagePath     string   `yaml:"imagePath"`
-	Type          string   `yaml:"type"`
-	Tags          []string `yaml:"tags"`
+	Title       string   `yaml:"title"`
+	Description string   `yaml:"description"`
+	Category    string   `yaml:"category"`
+	ImagePath   string   `yaml:"imagePath"`
+	Type        string   `yaml:"type"`
+	Tags        []string `yaml:"tags"`
 }
 
 func parseMetadata(input []byte) (meta Metadata, markdown []byte, err error) {

--- a/markdown/metadata.go
+++ b/markdown/metadata.go
@@ -13,7 +13,7 @@ type Metadata struct {
 	Title       string   `yaml:"title"`
 	Description string   `yaml:"description"`
 	Category    string   `yaml:"category"`
-	ImagePath   string   `yaml:"imagePath"`
+	ImageURL    string   `yaml:"imageURL"`
 	Type        string   `yaml:"type"`
 	Tags        []string `yaml:"tags"`
 }

--- a/markdown/metadata.go
+++ b/markdown/metadata.go
@@ -10,11 +10,13 @@ import (
 type Metadata struct {
 	IgnoreDisconnectedPageCheck bool `yaml:"ignoreDisconnectedPageCheck"`
 
-	Title       string   `yaml:"title"`
-	Description string   `yaml:"description"`
-	Category    string   `yaml:"category"`
-	Type        string   `yaml:"type"`
-	Tags        []string `yaml:"tags"`
+	Title         string   `yaml:"title"`
+	Description   string   `yaml:"description"`
+	Category      string   `yaml:"category"`
+	CanonicalPath string   `yaml:"canonicalPath"`
+	ImagePath     string   `yaml:"imagePath"`
+	Type          string   `yaml:"type"`
+	Tags          []string `yaml:"tags"`
 }
 
 func parseMetadata(input []byte) (meta Metadata, markdown []byte, err error) {

--- a/markdown/metadata.go
+++ b/markdown/metadata.go
@@ -8,8 +8,13 @@ import (
 
 // Metadata is document metadata in the "front matter" of a Markdown document.
 type Metadata struct {
-	Title                       string `yaml:"title"`
-	IgnoreDisconnectedPageCheck bool   `yaml:"ignoreDisconnectedPageCheck"`
+	IgnoreDisconnectedPageCheck bool `yaml:"ignoreDisconnectedPageCheck"`
+
+	Title       string   `yaml:"title"`
+	Description string   `yaml:"description"`
+	Category    string   `yaml:"category"`
+	Type        string   `yaml:"type"`
+	Tags        []string `yaml:"tags"`
 }
 
 func parseMetadata(input []byte) (meta Metadata, markdown []byte, err error) {
@@ -26,7 +31,9 @@ func parseMetadata(input []byte) (meta Metadata, markdown []byte, err error) {
 		return meta, input, nil // no metadata (because no ending delimiter)
 	}
 
-	err = yaml.Unmarshal(input[:len(startMarker)+end], &meta)
+	// UnmarshalStrict prevents to add incorrect metadata that would be really
+	// hard to detect, ex: "Description" instead of "description".
+	err = yaml.UnmarshalStrict(input[:len(startMarker)+end], &meta)
 	markdown = input[len(startMarker)+end+len(endMarker):]
 	return meta, markdown, err
 }

--- a/markdown/metadata_test.go
+++ b/markdown/metadata_test.go
@@ -1,0 +1,32 @@
+package markdown
+
+import "testing"
+
+func TestMetadata(t *testing.T) {
+	t.Run("parseMetadata", func(t *testing.T) {
+		t.Run("OK", func(t *testing.T) {
+			frontMatter := `---
+category: article
+---
+`
+			meta, _, err := parseMetadata([]byte(frontMatter))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := "article"; want != meta.Category {
+				t.Errorf("got data %q, want %q", meta.Category, want)
+			}
+		})
+
+		t.Run("NOK unknown keys", func(t *testing.T) {
+			frontMatter := `---
+Category: article
+---
+`
+			_, _, err := parseMetadata([]byte(frontMatter))
+			if err == nil {
+				t.Errorf("got no error, want not nil err")
+			}
+		})
+	})
+}

--- a/site.go
+++ b/site.go
@@ -34,6 +34,11 @@ type Site struct {
 	// site is available.
 	Base *url.URL
 
+	// Root is the root URL that is only used for specific cases where an absolute URL is mandatory,
+	// such as for opengraph tags in the headers for example. It must include both the scheme and
+	// host.
+	Root *url.URL
+
 	// Templates is the file system containing the Go html/template templates used to render site
 	// pages
 	Templates http.FileSystem

--- a/template.go
+++ b/template.go
@@ -69,6 +69,17 @@ func (s *Site) getTemplate(templatesFS http.FileSystem, name string, extraFuncs 
 		"subtract":   func(a, b int) int { return a - b },
 		"replace":    strings.Replace,
 		"trimPrefix": strings.TrimPrefix,
+		"hasRootURL": func() bool {
+			return s.Root != nil
+		},
+		"absURL": func(path string) string {
+			if s.Root != nil {
+				url := *s.Root
+				url.Path = path
+				return url.String()
+			}
+			return path
+		},
 	})
 	tmpl.Funcs(extraFuncs)
 


### PR DESCRIPTION
This PR adds more fields to the metadata, enabling us to use frontmatter to set open graph tags for SEO. It partly addresses https://github.com/sourcegraph/docsite/issues/65 

Design-wise, all new fields are hardcoded in the metadata struct. No error will be raised if they aren't present. But any key not referenced by the `Metadata` struct will raise an error. 

A plain old `meta` field in the front matter could have been a good choice, but my primary concern with that is that have no way to ensure that those fields are properly populated, which would result in believing that the pages are properly annotated while they are not, which is difficult to spot. There are ways to fix this, but this requires additional work.

I'm adding below, for convenience, what the `root.html` template may look like with those:

```html
      <meta content="{{ .Content.Doc.Title }} - Sourcegraph docs" property="og:title">
      {{ if .Content.Doc.Meta.Type }}
      <meta content="{{ .Content.Doc.Meta.Type }}" property="og:type">
      {{ else }}
      <meta content="website" property="og:type">
      {{ end }}
      {{ if .Content.Doc.Meta.Description }}
      <meta content="{{ .Content.Doc.Meta.Description }}" property="og:description">
      {{ end }}
      {{ if .Content.Doc.Meta.Category }}
      <meta content="{{ .Content.Doc.Meta.Category }}" property="article:section">
      {{ end }}
      {{ if .Content.Doc.Meta.Tags }}
      {{ range $i, $tag:= .Content.Doc.Meta.Tags }}
      <meta content="{{ $tag }}" property="article:tag">
      {{ end }}
      {{ end }}
```
