### PR TITLE
Bump go version to 1.17.

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Compile and release
-      uses: sourcegraph/go-release.action@v1.1.0
+      uses: sourcegraph/go-release.action@v1.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CGO_ENABLED: 0
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Compile and release
-      uses: sourcegraph/go-release.action@v1.1.0
+      uses: sourcegraph/go-release.action@v1.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CGO_ENABLED: 0
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Compile and release
-      uses: sourcegraph/go-release.action@v1.1.0
+      uses: sourcegraph/go-release.action@v1.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CGO_ENABLED: 0

--- a/go.mod
+++ b/go.mod
@@ -24,4 +24,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.7
 )
 
-go 1.13
+go 1.17


### PR DESCRIPTION
Blocked on creating a `v1.2.0` tag in https://github.com/sourcegraph/go-release.action **DONE**