### PR TITLE
add strings.Contains to the template file FuncMap

### DIFF
--- a/template.go
+++ b/template.go
@@ -69,6 +69,7 @@ func (s *Site) getTemplate(templatesFS http.FileSystem, name string, extraFuncs 
 		"subtract":   func(a, b int) int { return a - b },
 		"replace":    strings.Replace,
 		"trimPrefix": strings.TrimPrefix,
+		"contains":   strings.Contains,
 		"hasRootURL": func() bool {
 			return s.Root != nil
 		},


### PR DESCRIPTION
We will need to conditionally check against the file path, so adding `strings.Contains` to the available template functions.