### PR TITLE
Make rel links checker more precise.

### DIFF
--- a/check.go
+++ b/check.go
@@ -102,7 +102,7 @@ func (s *Site) checkContentPage(page *contentPageCheckData) (problems []string) 
 			}
 
 			if node.Type == blackfriday.Link {
-				// Require that relative paths link to the actual .md file, i.e not the the "foo" folder in the case of
+				// Require that relative paths link to the actual .md file, i.e not the "foo" folder in the case of
 				// of "foo/index.md", so that browsing docs on the file system works.
 				if isPathOnly && u.Path != "" && filepath.Ext(u.Path) == "" {
 					problems = append(problems, fmt.Sprintf("must link to .md file, not %s", u.Path))

--- a/check.go
+++ b/check.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -101,9 +102,9 @@ func (s *Site) checkContentPage(page *contentPageCheckData) (problems []string) 
 			}
 
 			if node.Type == blackfriday.Link {
-				// Require that relative paths link to the actual .md file, so that browsing
-				// docs on the file system works.
-				if isPathOnly && u.Path != "" && !strings.HasSuffix(u.Path, ".md") {
+				// Require that relative paths link to the actual .md file, i.e not the the "foo" folder in the case of
+				// of "foo/index.md", so that browsing docs on the file system works.
+				if isPathOnly && u.Path != "" && filepath.Ext(u.Path) == "" {
 					problems = append(problems, fmt.Sprintf("must link to .md file, not %s", u.Path))
 				}
 			}


### PR DESCRIPTION
The predicate used to detect a link pointing to "foo" where the actual
page is at "foo/index.md" was too narrow and prevented to link to other
filetypes such as .csv.

It nows check if the linked file has an extension rather than this
extension just being ".md", which enables to link to CSV files for
example.

# Test plan

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/10151/170967527-ef721f2e-7360-40e7-b710-9ebb7d3adb92.png">
