### PR TITLE
check: output problems to stderr

### DIFF
--- a/cmd/docsite/check.go
+++ b/cmd/docsite/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 )
 
 func init() {
@@ -24,7 +25,7 @@ func init() {
 		}
 		if len(problems) > 0 {
 			for _, problem := range problems {
-				fmt.Println(problem)
+				fmt.Fprintln(os.Stderr, problem)
 			}
 			return fmt.Errorf("%d problems found", len(problems))
 		}


### PR DESCRIPTION
the error that is returned in `init()` gets outputted to stderr, while the problems that were printed just before it were outputted to stderr. On a terminal one won't notice it, but once you have scripts/commands that read from stderr and stdout seperately and do different things, the output gets disjointed.

As can be seen here https://sourcegraph.slack.com/archives/C01N83PS4TU/p1664207483448289

### Test plan
1. Build docsite.
2. Copy to `sourcegraph/sourcegraph`
3. Run `./docsite check >stdout.txt 2>stderr.txt`
4. `stdout.txt` should be empty and `stderr.txt` should have all the error output