### PR TITLE
markdown: support soft-line breaks

### DIFF
--- a/markdown/extender.go
+++ b/markdown/extender.go
@@ -172,11 +172,13 @@ func (r *nodeRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 			return ast.WalkContinue, nil
 		}
 
-		// We always need a line break because each ast.Text node represents a line
-		defer func() { _ = w.WriteByte('\n') }()
-
 		n := node.(*ast.Text)
 		text := n.Text(source)
+		if len(text) == 0 {
+			// Simply write a line break if there is no text in the node, otherwise, soft break lines are sticking.
+			_ = w.WriteByte('\n')
+			return ast.WalkContinue, nil
+		}
 
 		// Rewrites `{#foo}` directives in text to `<a id="foo"></a>` anchors.
 		matches := anchorDirectivePattern.FindAllIndex(text, -1)

--- a/markdown/extender.go
+++ b/markdown/extender.go
@@ -172,6 +172,9 @@ func (r *nodeRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 			return ast.WalkContinue, nil
 		}
 
+		// We always need a line break because each ast.Text node represents a line
+		defer func() { _ = w.WriteByte('\n') }()
+
 		n := node.(*ast.Text)
 		text := n.Text(source)
 

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -71,7 +71,6 @@ func New(opts Options) goldmark.Markdown {
 			parser.WithAttribute(),
 		),
 		goldmark.WithRendererOptions(
-			goldmarkhtml.WithHardWraps(),
 			goldmarkhtml.WithXHTML(),
 			goldmarkhtml.WithUnsafe(),
 		),

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -134,7 +134,9 @@ func TestRenderer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := `<h1 id="b"><a name="b" class="anchor" href="#b" rel="nofollow" aria-hidden="true" title="#b"></a>a</h1>` + "\n"
+			want := `<h1 id="b"><a name="b" class="anchor" href="#b" rel="nofollow" aria-hidden="true" title="#b"></a>a
+</h1>
+`
 			if string(doc.HTML) != want {
 				t.Errorf("got %q, want %q", string(doc.HTML), want)
 			}


### PR DESCRIPTION
We have not been using hard-wrap for lines, and soft-break lines will be sticking without proper new line characters.

Fixes https://github.com/sourcegraph/docsite/issues/91

## Test plan

Before:

<img width="858" alt="CleanShot 2023-02-13 at 19 47 28@2x" src="https://user-images.githubusercontent.com/2946214/218449889-167e232f-0a9b-4bd0-8a0d-ace703829284.png">

After:

<img width="832" alt="CleanShot 2023-02-13 at 19 47 51@2x" src="https://user-images.githubusercontent.com/2946214/218449946-3f589eb4-be6e-4cbf-99b2-b0a9753eebe9.png">

