### PR TITLE
markdown: really fix soft line break rendering

### DIFF
--- a/markdown/extender.go
+++ b/markdown/extender.go
@@ -173,10 +173,12 @@ func (r *nodeRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 		}
 
 		n := node.(*ast.Text)
+		if n.SoftLineBreak() {
+			defer func() { _ = w.WriteByte('\n') }()
+		}
+
 		text := n.Text(source)
 		if len(text) == 0 {
-			// Simply write a line break if there is no text in the node, otherwise, soft break lines are sticking.
-			_ = w.WriteByte('\n')
 			return ast.WalkContinue, nil
 		}
 

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -134,8 +134,7 @@ func TestRenderer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := `<h1 id="b"><a name="b" class="anchor" href="#b" rel="nofollow" aria-hidden="true" title="#b"></a>a
-</h1>
+			want := `<h1 id="b"><a name="b" class="anchor" href="#b" rel="nofollow" aria-hidden="true" title="#b"></a>a</h1>
 `
 			if string(doc.HTML) != want {
 				t.Errorf("got %q, want %q", string(doc.HTML), want)


### PR DESCRIPTION
https://github.com/sourcegraph/docsite/pull/92 wasn't a good fix, now for real.