### PR TITLE
docsite: build/push the docker container on release

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -42,3 +42,24 @@ jobs:
         PACKAGE: ./cmd/docsite
         GOARCH: arm64
         GOOS: darwin
+  docker:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_USERNAME }}
+
+      - name: build-docsite-image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            sourcegraph/docsite:latest
+            sourcegraph/docsite:${{ github.event.release.tag_name }}


### PR DESCRIPTION
Builds and pushes the docsite docker image when a release is created. Given this is already largely taken care of in a github action, I'm making an exception to my otherwise distaste for them and just adding to this hear. 


