### PR TITLE
update sg/sg refs to point to sourcegraph-public-snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The templates use [Go-style HTML templates](https://golang.org/pkg/html/template
 See the following examples:
 
 - [about.sourcegraph.com/handbook templates](https://github.com/sourcegraph/about/tree/master/_resources/templates)
-- [docs.sourcegraph.com templates](https://github.com/sourcegraph/sourcegraph/tree/main/doc/_resources/templates)
+- [docs.sourcegraph.com templates](https://github.com/sourcegraph/sourcegraph-public-snapshot/tree/main/doc/_resources/templates)
 
 ### Redirects
 
@@ -110,7 +110,7 @@ The `docsite` tool requires site data to be available in any of the following wa
   ```
 - In the `DOCSITE_CONFIG` env var, using Zip archive URLs for `templates`, `assets`, and `content`, as in the following example:
   ```
-  DOCSITE_CONFIG='{"templates":"https://codeload.github.com/sourcegraph/sourcegraph/zip/refs/heads/main#*/doc/_resources/templates/","assets":"https://codeload.github.com/sourcegraph/sourcegraph/zip/refs/heads/main#*/doc/_resources/assets/","content":"https://codeload.github.com/sourcegraph/sourcegraph/zip/refs/heads/$VERSION#*/doc/","baseURLPath":"/","assetsBaseURLPath":"/assets/","defaultContentBranch":"main"}' docsite serve
+  DOCSITE_CONFIG='{"templates":"https://codeload.github.com/sourcegraph/sourcegraph-public-snapshot/zip/refs/heads/main#*/doc/_resources/templates/","assets":"https://codeload.github.com/sourcegraph/sourcegraph/zip/refs/heads/main#*/doc/_resources/assets/","content":"https://codeload.github.com/sourcegraph/sourcegraph/zip/refs/heads/$VERSION#*/doc/","baseURLPath":"/","assetsBaseURLPath":"/assets/","defaultContentBranch":"main"}' docsite serve
   ```
 
 ## Development

--- a/cmd/docsite/site.go
+++ b/cmd/docsite/site.go
@@ -172,7 +172,7 @@ func addRedirectsFromAssets(site *docsite.Site) error {
 
 const (
 	DEBUG        = false
-	CODEHOST_URL = "https://codeload.github.com/sourcegraph/sourcegraph/zip/refs/heads/$VERSION#*/doc/"
+	CODEHOST_URL = "https://codeload.github.com/sourcegraph/sourcegraph-public-snapshot/zip/refs/heads/$VERSION#*/doc/"
 )
 
 // openDocsiteFromConfig reads the documentation site data from a docsite.json file. All file system
@@ -324,7 +324,7 @@ func (fs *versionedFileSystemURL) fetchAndCacheVersion(version string) (http.Fil
 	}
 	urlStr = strings.Replace(fs.url, "$VERSION", version, -1)
 
-	// HACK: Workaround for https://github.com/sourcegraph/sourcegraph/issues/3030. This assumes
+	// HACK: Workaround for https://github.com/sourcegraph/sourcegraph-public-snapshot/issues/3030. This assumes
 	// that tags all begin with "vN" where N is some number.
 	if len(version) >= 2 && version[0] == 'v' && unicode.IsDigit(rune(version[1])) {
 		urlStr = strings.Replace(urlStr, "refs/heads/", "refs/tags/", 1)


### PR DESCRIPTION
Update all references to `sourcegraph/sourcegraph` to point to `sourcegraph/sourcegraph-public-snapshot`