### PR TITLE
bump go-release.action to 1.3

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Compile and release
-      uses: sourcegraph/go-release.action@v1.2.0
+      uses: sourcegraph/go-release.action@v1.3.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CGO_ENABLED: 0
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Compile and release
-      uses: sourcegraph/go-release.action@v1.2.0
+      uses: sourcegraph/go-release.action@v1.3.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CGO_ENABLED: 0
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Compile and release
-      uses: sourcegraph/go-release.action@v1.2.0
+      uses: sourcegraph/go-release.action@v1.3.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CGO_ENABLED: 0


### PR DESCRIPTION
Update to use this new release https://github.com/sourcegraph/go-release.action/releases/tag/v1.3.0