### PR TITLE
chore(release): specify workflow inputs

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,6 +1,12 @@
 name: Go release
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag'
+        default: '{{ github.event.release.tag_name }}'
+        required: true
+        type: string
   release:
     types: [published]
 jobs:
@@ -9,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+      with:
+          ref: '{{ inputs.release_tag }}'
     - name: Compile and release
       uses: sourcegraph/go-release.action@v1.3.0
       env:
@@ -23,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+      with:
+          ref: '{{ inputs.release_tag }}'
     - name: Compile and release
       uses: sourcegraph/go-release.action@v1.3.0
       env:
@@ -37,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+      with:
+          ref: '{{ inputs.release_tag }}'
     - name: Compile and release
       uses: sourcegraph/go-release.action@v1.3.0
       env:
@@ -52,9 +64,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          ref: '{{ inputs.release_tag }}'
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_PASSWORD }}
           password: ${{ secrets.DOCKER_USERNAME }}
@@ -66,4 +80,4 @@ jobs:
           push: true
           tags: |
             sourcegraph/docsite:latest
-            sourcegraph/docsite:${{ github.event.release.tag_name }}
+            sourcegraph/docsite:${{ inputs.release_tag }}


### PR DESCRIPTION
You sometimes want to run the release action manually and currently it is impossible unless you create tag. With this we make it so that we can trigger the workflow manually