### PR TITLE
Update redirect logic to redirect versions ≥ 5.2 to new docs domain

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -14,7 +14,7 @@ import (
 // versionPattern matches version strings like @5.2, @5.2.0, etc. and captures major and minor version numbers
 var versionPattern = regexp.MustCompile(`^@(\d+)\.(\d+)(?:\.(\d+))?$`)
 
-// shouldRedirectVersion returns true for versions ≥ 5.3 (format: @major.minor[.patch])
+// shouldRedirectVersion returns true for versions ≥ 5.2 (format: @major.minor[.patch])
 func shouldRedirectVersion(version string) bool {
 	matches := versionPattern.FindStringSubmatch(version)
 	if len(matches) < 3 {
@@ -27,7 +27,7 @@ func shouldRedirectVersion(version string) bool {
 		return false
 	}
 	
-	return major > 5 || (major == 5 && minor >= 3)
+	return major > 5 || (major == 5 && minor >= 2)
 }
 
 // Handler returns an http.Handler that serves the site.
@@ -146,7 +146,7 @@ func (s *Site) Handler() http.Handler {
 				contentVersion = r.URL.Path[1 : 1+end]
 			}
 			
-			// Redirect versions ≥ 5.3 to new docs domain with path preservation
+			// Redirect versions ≥ 5.2 to new docs domain with path preservation
 			version := "@" + contentVersion
 			if shouldRedirectVersion(version) {
 				newURL := "https://www.sourcegraph.com/docs/" + contentVersion + "/"

--- a/handler_test.go
+++ b/handler_test.go
@@ -272,11 +272,14 @@ func TestSite_Handler(t *testing.T) {
 			checkResponseStatus(t, rr, http.StatusNotFound)
 		})
 
-		t.Run("version 5.2 - no redirect", func(t *testing.T) {
+		t.Run("version 5.2 - should redirect", func(t *testing.T) {
 			rr := httptest.NewRecorder()
 			req, _ := http.NewRequest("GET", "/@5.2", nil)
 			handler.ServeHTTP(rr, req)
-			checkResponseStatus(t, rr, http.StatusNotFound)
+			checkResponseStatus(t, rr, http.StatusPermanentRedirect)
+			if got, want := rr.Header().Get("Location"), "https://www.sourcegraph.com/docs/5.2/"; got != want {
+				t.Errorf("got redirect Location %q, want %q", got, want)
+			}
 		})
 
 		t.Run("version 5.3 - should redirect", func(t *testing.T) {


### PR DESCRIPTION
we need to redirect from 5.2 onwards