### PR TITLE
Use errors.Is/errors.As instead of == comparisons against errors

### DIFF
--- a/markdown/func.go
+++ b/markdown/func.go
@@ -3,6 +3,7 @@ package markdown
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"strings"
@@ -18,7 +19,7 @@ func EvalMarkdownFuncs(ctx context.Context, htmlFragment []byte, opt Options) ([
 	for {
 		tt := z.Next()
 		if tt == html.ErrorToken {
-			if z.Err() == io.EOF {
+			if stderrors.Is(z.Err(), io.EOF) {
 				break
 			}
 			return nil, errors.WithMessage(z.Err(), "while evaluating Markdown function tags")
@@ -91,7 +92,7 @@ func consumeUntilCloseTag(z *html.Tokenizer, funcName string) error {
 	for {
 		tt := z.Next()
 		if tt == html.ErrorToken {
-			if z.Err() == io.EOF {
+			if stderrors.Is(z.Err(), io.EOF) {
 				return fmt.Errorf("tag for Markdown function %q is never closed", funcName)
 			}
 			return errors.WithMessagef(z.Err(), "while scanning for Markdown function close tag %q", funcName)

--- a/markdown/html.go
+++ b/markdown/html.go
@@ -2,6 +2,7 @@ package markdown
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/url"
 	"strings"
@@ -30,7 +31,7 @@ func rewriteRelativeURLsInHTML(htmlFragment []byte, opt Options) ([]byte, error)
 	var buf bytes.Buffer
 	for {
 		tt := z.Next()
-		if tt == html.ErrorToken && z.Err() == io.EOF {
+		if tt == html.ErrorToken && errors.Is(z.Err(), io.EOF) {
 			break
 		}
 		tok := z.Token()
@@ -83,7 +84,7 @@ func isOnlyHTMLComment(htmlFragment []byte) bool {
 				continue
 			}
 		}
-		if tt == html.ErrorToken && z.Err() == io.EOF {
+		if tt == html.ErrorToken && errors.Is(z.Err(), io.EOF) {
 			break
 		}
 		return false


### PR DESCRIPTION
This change replaces direct `==`/`!=` comparisons against error values with the
standard library helpers `errors.Is` (for sentinel error values) and `errors.As`
(for error types).

Direct comparison breaks when an error is wrapped (e.g. with `fmt.Errorf("...: %w", err)`),
whereas `errors.Is`/`errors.As` traverse the wrap chain.

Notes:
- Comparisons against `nil` are intentionally left unchanged.
- Test files, vendored code, and generated code were not modified.

[_Created by Sourcegraph batch change `bahrmichael/432ac474-d2a7-4950-b17f-2a1b1fe59e87`._](https://sourcegraph.sourcegraph.com/users/bahrmichael/batch-changes/432ac474-d2a7-4950-b17f-2a1b1fe59e87)