### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.26.4-alpine as builder
 ENV GO111MODULE on
 COPY . $GOPATH/src/github.com/sourcegraph/docsite
 WORKDIR $GOPATH/src/github.com/sourcegraph/docsite

--- a/cmd/docsite/cmd.go
+++ b/cmd/docsite/cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -42,12 +43,7 @@ func (c *command) matches(name string) bool {
 	if name == c.FlagSet.Name() {
 		return true
 	}
-	for _, alias := range c.aliases {
-		if name == alias {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.aliases, name)
 }
 
 // commander represents a top-level command with subcommands.

--- a/cmd/docsite/site.go
+++ b/cmd/docsite/site.go
@@ -151,7 +151,7 @@ func addRedirectsFromAssets(site *docsite.Site) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	for _, line := range bytes.Split(raw, []byte("\n")) {
+	for line := range bytes.SplitSeq(raw, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 || line[0] == '#' {
 			continue

--- a/funcs.go
+++ b/funcs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/url"
 	"strings"
 	"text/template"
@@ -108,9 +109,7 @@ func createMarkdownFuncs(site *Site) markdown.FuncMap {
 			return string(doc.HTML), nil
 		},
 	}
-	for name, f := range testMarkdownFuncs {
-		m[name] = f
-	}
+	maps.Copy(m, testMarkdownFuncs)
 	return m
 }
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
-
-toolchain go1.23.2
+go 1.26.4

--- a/handler.go
+++ b/handler.go
@@ -20,13 +20,13 @@ func shouldRedirectVersion(version string) bool {
 	if len(matches) < 3 {
 		return false
 	}
-	
+
 	major, err1 := strconv.Atoi(matches[1])
 	minor, err2 := strconv.Atoi(matches[2])
 	if err1 != nil || err2 != nil {
 		return false
 	}
-	
+
 	return major > 5 || (major == 5 && minor >= 2)
 }
 
@@ -145,7 +145,7 @@ func (s *Site) Handler() http.Handler {
 				urlPath = r.URL.Path[1+end+1:]
 				contentVersion = r.URL.Path[1 : 1+end]
 			}
-			
+
 			// Redirect versions ≥ 5.2 to new docs domain with path preservation
 			version := "@" + contentVersion
 			if shouldRedirectVersion(version) {
@@ -156,7 +156,7 @@ func (s *Site) Handler() http.Handler {
 				http.Redirect(w, r, newURL, http.StatusPermanentRedirect)
 				return
 			}
-			
+
 			r = requestShallowCopyWithURLPath(r, urlPath)
 		}
 
@@ -196,8 +196,8 @@ func (s *Site) Handler() http.Handler {
 			filePath, fileData, err := resolveAndReadAll(content, r.URL.Path)
 			if err == nil {
 				// Strip trailing slashes for consistency.
-				if strings.HasSuffix(r.URL.Path, "/") {
-					http.Redirect(w, r, path.Join(basePath, strings.TrimSuffix(r.URL.Path, "/")), http.StatusMovedPermanently)
+				if before, ok := strings.CutSuffix(r.URL.Path, "/"); ok {
+					http.Redirect(w, r, path.Join(basePath, before), http.StatusMovedPermanently)
 					return
 				}
 

--- a/internal/search/excerpt.go
+++ b/internal/search/excerpt.go
@@ -29,10 +29,7 @@ func excerpt(text []byte, start, end, maxChars int) []byte {
 	}
 
 	if index := bytes.LastIndexAny(text[origEnd:end], breakChars); index != -1 {
-		end = origEnd + index + 1
-		if end > len(text) {
-			end = len(text)
-		}
+		end = min(origEnd+index+1, len(text))
 	}
 
 	return bytes.TrimSpace(text[start:end])

--- a/markdown/extender.go
+++ b/markdown/extender.go
@@ -115,7 +115,7 @@ func (r *nodeRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 
 		var val []byte
 		l := n.Segments.Len()
-		for i := 0; i < l; i++ {
+		for i := range l {
 			segment := n.Segments.At(i)
 			val = append(val, segment.Value(source)...)
 		}


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)